### PR TITLE
plistをs3へ動的アップロード(ios7.1対応)

### DIFF
--- a/mainmodules/package/actions/installActions.php
+++ b/mainmodules/package/actions/installActions.php
@@ -30,8 +30,32 @@ class installActions extends packageActions
 			// itms-service での接続はセッションを引き継げない
 			// 一時トークンをURLパラメータに付けることで認証する
 			$scheme = Config::get('enable_https')?'https':null; // HTTPSが使えるならHTTPS優先
+			/*
 			$plist_url = mfwHttp::composeUrl(
 				mfwRequest::makeUrl('/package/install_plist',$scheme),
+				array(
+					'id' => $this->package->getId(),
+					't' => $this->makeToken(),
+					));
+			$url = 'itms-services://?action=download-manifest&url='.urlencode($plist_url);
+			*/
+
+			$pkg = $this->package;
+			$app = $pkg->getApplication();
+
+			$ipa_url = $pkg->getFileUrl('+60 min');
+			$image_url = $app->getIconUrl();
+			$bundle_identifier = $pkg->getIOSIdentifier();
+			$pkg_title = $pkg->getTitle();
+			$app_title = $app->getTitle();
+
+			ob_start();
+			include APP_ROOT.'/data/templates/package/install_plist.php';
+			$plist = ob_get_clean();
+		
+			$plist_key = Package::uploadTempPlist($plist);
+			$plist_url = mfwHttp::composeUrl(
+				Package::getTempPlistUrl($plist_key,'+60 min'),
 				array(
 					'id' => $this->package->getId(),
 					't' => $this->makeToken(),

--- a/model/Package.php
+++ b/model/Package.php
@@ -19,6 +19,7 @@ class Package extends mfwObject {
 
 	const FILE_DIR = 'package/';
 	const TEMP_DIR = 'temp-data/';
+	const TEMP_PLIST_DIR = 'temp-data/plist/';
 
 	// AppStore, GooglePlayでの制限ファイルサイズ(MB)
 	const IOS_FILE_SIZE_LIMIT_MB = 100;
@@ -123,6 +124,12 @@ class Package extends mfwObject {
 		$key = $this->getFileKey();
 		S3::uploadFile($key,$file_path,$mime,'private');
 	}
+	public static function uploadTempPlist($plist)
+	{
+		$tmp_name = Random::string(16).".plist";
+		S3::uploadDataWithExpire(static::TEMP_PLIST_DIR.$tmp_name,$plist,'text/xml','+60 min');
+		return $tmp_name;
+	}
 	public static function uploadTempFile($file_path,$ext,$mime)
 	{
 		$tmp_name = Random::string(16).".$ext";
@@ -143,6 +150,10 @@ class Package extends mfwObject {
 	public function getFileUrl($expire=null)
 	{
 		return S3::url($this->getFileKey(),$expire);
+	}
+	public static function getTempPlistUrl($temp_name,$expire=null)
+	{
+		return S3::url(static::TEMP_PLIST_DIR.$temp_name,$expire);
 	}
 
 	public function getInstallUrl()

--- a/model/S3.php
+++ b/model/S3.php
@@ -38,6 +38,21 @@ class S3 {
 		return $r;
 	}
 
+	public static function uploadDataWithExpire($key,$data,$type,$expires,$acl='private')
+	{
+		$s3 = static::singleton();
+		$r = $s3->client->putObject(
+			array(
+				'Bucket' => $s3->config['bucket_name'],
+				'Key' => $key,
+				'ACL' => $acl,
+				'ContentType' => $type,
+				'Body' => Guzzle\Http\EntityBody::factory($data),
+				'Expires' => $expires
+				));
+		return $r;
+	}
+
 	public static function uploadFile($key,$filename,$type,$acl='private')
 	{
 		$s3 = static::singleton();


### PR DESCRIPTION
はじめまして
emlauncherとても便利で利用させていただいております。

ios7.1以降のOSで、アプリをダウンロードするときにhttps＆認証済み証明書になっており、
ちょっと敷居が高くなっていたので、s3に一時的にplistをアップすることで、上記の問題を
解決しております。

もしよろしければ、マージをお願いいたします。
（GitHubへの初プルリクエストなため、作法等いろいろ間違っているかもしれません。その際はご指摘
いただけますと幸いです）