### PR TITLE
emlauncher_configでbundletoolが利用するaapt2のパスを指定する機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ APKを再署名するためのキーストアも用意します。
 keytool -genkey -keystore {emlauncher-keystore.jks} -keyalg RSA -keysize 2048 -validity 10000 -alias {key-alias}
 ```
 
+#### AARCH64(ARM64)アーキテクチャのプラットホームで動作させる場合
+AARCH64(ARM64)アーキテクチャのプラットホームで動作させる場合にはbundletoolに内包のaapt2がAMD64(x86_64)アーキテクチャ向けでそのままでは動作しないのでARM64アーキテクチャー用のaapt2をgithubからダウンロードします。
+```BASH
+curl -sLO https://github.com/JonForShort/android-tools/raw/master/build/android-9.0.0_r33/aapt2/arm64-v8a/bin/aapt2
+```
+
 ### 8. Configuration
 
 #### mfw_serverevn_config.php
@@ -106,6 +112,9 @@ keytool -genkey -keystore {emlauncher-keystore.jks} -keyalg RSA -keysize 2048 -v
 ``config/emlauncher_config_sample.php``をコピーし、自身の環境に合わせて書き換えます。
 
 S3のbucket名に指定するbucketは予め作成しておきます。
+
+##### AARCH64(ARM64)アーキテクチャのプラットホームで動作させる場合
+APKファイルの設定のaapt2に(6.)でダウンロードしたARM64向けaapt2実行ファイルのパスを指定します。
 
 ### 9. Complete
 

--- a/config/emlauncher_config_sample.php
+++ b/config/emlauncher_config_sample.php
@@ -130,7 +130,7 @@ $emlauncher_config = array(
 			/** キーのパスワード 書式はbundletoolのkey-passオプションと同じ. */
 			'keypass' => 'pass:xxxxxxxx',
 			/** BundleTool内包のaapt2以外を使うなら指定 */
-			'aapt2' = '/path/to/aapt2',
+			'aapt2' => '/path/to/aapt2',
 			),
 		),
 

--- a/config/emlauncher_config_sample.php
+++ b/config/emlauncher_config_sample.php
@@ -129,6 +129,8 @@ $emlauncher_config = array(
 
 			/** キーのパスワード 書式はbundletoolのkey-passオプションと同じ. */
 			'keypass' => 'pass:xxxxxxxx',
+			/** BundleTool内包のaapt2以外を使うなら指定 */
+			'aapt2' = '/path/to/aapt2',
 			),
 		),
 
@@ -168,6 +170,7 @@ $emlauncher_config = array(
 			'keyalias' => 'emlauncher',
 			'kspass' => 'pass:emlauncher',
 			'keypass' => 'pass:emlauncher',
+			'aapt2' => '/aapt2',
 			),
 		),
 	);

--- a/docker/db/Dockerfile
+++ b/docker/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.7
+FROM mysql/mysql-server:5.7
 ENV TZ: Asia/Tokyo
 
 COPY init/00_database.sql /docker-entrypoint-initdb.d/

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -32,4 +32,5 @@ RUN set -x \
   && apt-get install -y --no-install-recommends default-jre-headless \
   && curl -sL -o/bundletool.jar https://github.com/google/bundletool/releases/download/1.4.0/bundletool-all-1.4.0.jar \
   && curl -sL -o/aapt2 https://github.com/JonForShort/android-tools/raw/master/build/android-9.0.0_r33/aapt2/arm64-v8a/bin/aapt2 \
+  && chmod 755 /aapt2 \
   && echo -e 'EMLauncher\n\nKLab Inc.\n\nTokyo\nJP\nyes' | keytool -genkeypair -keystore /emlauncher.keystore -alias emlauncher -storepass emlauncher -keypass emlauncher -keyalg RSA -keysize 2048 -validity 36524

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -31,4 +31,5 @@ RUN set -x \
   && mkdir -p /usr/share/man/man1 \
   && apt-get install -y --no-install-recommends default-jre-headless \
   && curl -sL -o/bundletool.jar https://github.com/google/bundletool/releases/download/1.4.0/bundletool-all-1.4.0.jar \
+  && curl -sL -o/aapt2 https://github.com/JonForShort/android-tools/raw/master/build/android-9.0.0_r33/aapt2/arm64-v8a/bin/aapt2 \
   && echo -e 'EMLauncher\n\nKLab Inc.\n\nTokyo\nJP\nyes' | keytool -genkeypair -keystore /emlauncher.keystore -alias emlauncher -storepass emlauncher -keypass emlauncher -keyalg RSA -keysize 2048 -validity 36524

--- a/model/APKFile.php
+++ b/model/APKFile.php
@@ -49,7 +49,7 @@ class APKFile {
 			" --ks-pass=\"{$conf['kspass']}\"".
 			" --ks-key-alias=\"{$conf['keyalias']}\"".
 			" --key-pass=\"{$conf['keypass']}\"";
-		if ( !empty($conf['aapt2']) ) {
+		if(!empty($conf['aapt2'])){
 			$cmd .= " --aapt2=\"{$conf['aapt2']}\"";
 		}
 		exec($cmd, $out, $ret);

--- a/model/APKFile.php
+++ b/model/APKFile.php
@@ -49,6 +49,9 @@ class APKFile {
 			" --ks-pass=\"{$conf['kspass']}\"".
 			" --ks-key-alias=\"{$conf['keyalias']}\"".
 			" --key-pass=\"{$conf['keypass']}\"";
+		if ( !empty($conf['aapt2']) ) {
+			$cmd .= " --aapt2=\"{$conf['aapt2']}\"";
+		}
 		exec($cmd, $out, $ret);
 		if($ret!=0){
 			throw new RuntimeException("bundletool error: ".implode("\n", $out));


### PR DESCRIPTION
EMlauncherをランニングコストが安いEC2のGravitonインスタンスで実行して利用していますが、EMlauncherをaarch64アーキテクチャのプラットホームで実行した場合、androidの.aabファイルをアップロードした場合、bundletoolが内包しているx86_64アーキテクチャ用のaapt2を実行してしまうためアップロードされた.aabファイルの展開に失敗してしまいます。
そのためemlauncher_configでbundletoolが利用するaapt2のパスを指定できる機能を追加して、emlauncher_configにaapt2のパスが指定されている場合にはEMlauncherからのbundletoolの実行に--aapt2=pathを付加して内包のaapt2ではなく外部の指定されたパスに置かれたaapt2を実行できるような修正を加えました。
